### PR TITLE
[BI-48] Export blog to pdf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,6 +1066,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.15.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
+      "integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
+      "optional": true,
+      "requires": {
+        "core-js-pure": "^3.16.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
@@ -2058,6 +2068,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
+    },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
+      "optional": true
     },
     "@types/range-parser": {
       "version": "1.2.4",
@@ -3056,8 +3072,7 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autoprefixer": {
       "version": "9.8.6",
@@ -3245,6 +3260,12 @@
           }
         }
       }
+    },
+    "base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "optional": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -3532,6 +3553,11 @@
         "node-releases": "^1.1.73"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -3712,6 +3738,20 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
       "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
       "dev": true
+    },
+    "canvg": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.7.tgz",
+      "integrity": "sha512-4sq6iL5Q4VOXS3PL1BapiXIZItpxYyANVzsAKpTPS5oq4u3SKbGfUcbZh2gdLCQ3jWpG/y5wRkMlBBAJhXeiZA==",
+      "optional": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.9.6",
+        "@types/raf": "^3.4.0",
+        "raf": "^3.4.1",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^5.0.5"
+      }
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
@@ -4498,6 +4538,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.1.tgz",
+      "integrity": "sha512-EBMGdzQg7lHk3uI5bQ9NH56K+lx9HAl8pOmLarODePLLGkpwVEC1VydJTocuFchPlRDF7ZPxgKshyaM4CuV6Uw==",
+      "optional": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4627,6 +4673,15 @@
       "requires": {
         "postcss": "^7.0.1",
         "timsort": "^0.3.0"
+      }
+    },
+    "css-line-break": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.0.1.tgz",
+      "integrity": "sha512-gwKYIMUn7xodIcb346wgUhE2Dt5O1Kmrc16PWi8sL4FTfyDj8P5095rzH7+O8CTZudJr+uw2GCI/hwEkDJFI2w==",
+      "optional": true,
+      "requires": {
+        "base64-arraybuffer": "^0.2.0"
       }
     },
     "css-loader": {
@@ -5281,6 +5336,12 @@
           "dev": true
         }
       }
+    },
+    "dompurify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.1.tgz",
+      "integrity": "sha512-xGWt+NHAQS+4tpgbOAI08yxW0Pr256Gu/FNE2frZVTbgrBUn8M7tz7/ktS/LZ2MHeGqz6topj0/xY+y8R5FBFw==",
+      "optional": true
     },
     "domutils": {
       "version": "1.7.0",
@@ -6138,6 +6199,11 @@
         "websocket-driver": ">=0.5.1"
       }
     },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -6821,6 +6887,16 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
+      }
+    },
+    "html2canvas": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.3.2.tgz",
+      "integrity": "sha512-4+zqv87/a1LsaCrINV69wVLGG8GBZcYBboz1JPWEgiXcWoD9kroLzccsBRU/L9UlfV2MAZ+3J92U9IQPVMDeSQ==",
+      "optional": true,
+      "requires": {
+        "css-line-break": "2.0.1",
+        "text-segmentation": "^1.0.2"
       }
     },
     "htmlparser2": {
@@ -7776,6 +7852,20 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "jspdf": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.3.1.tgz",
+      "integrity": "sha512-1vp0USP1mQi1h7NKpwxjFgQkJ5ncZvtH858aLpycUc/M+r/RpWJT8PixAU7Cw/3fPd4fpC8eB/Bj42LnsR21YQ==",
+      "requires": {
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "fflate": "^0.4.8",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "jsprim": {
@@ -9068,8 +9158,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -10137,6 +10226,15 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "optional": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10246,8 +10344,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -10552,6 +10649,12 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
+    },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
+      "optional": true
     },
     "rimraf": {
       "version": "2.7.1",
@@ -11283,6 +11386,12 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
+    "stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "optional": true
+    },
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -11474,6 +11583,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-pathdata": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.5.tgz",
+      "integrity": "sha512-TAAvLNSE3fEhyl/Da19JWfMAdhSXTYeviXsLSoDT1UM76ADj5ndwAPX1FKQEgB/gFMPavOy6tOqfalXKUiXrow==",
+      "optional": true
     },
     "svg-tags": {
       "version": "1.0.0",
@@ -11975,6 +12090,15 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "text-segmentation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.2.tgz",
+      "integrity": "sha512-uTqvLxdBrVnx/CFQOtnf8tfzSXFm+1Qxau7Xi54j4OPTZokuDOX8qncQzrg2G8ZicAMOM8TgzFAYTb+AqNO4Cw==",
+      "optional": true,
+      "requires": {
+        "utrie": "^1.0.1"
       }
     },
     "text-table": {
@@ -12558,6 +12682,23 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
+    },
+    "utrie": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.1.tgz",
+      "integrity": "sha512-JPaDXF3vzgZxfeEwutdGzlrNoVFL5UvZcbO6Qo9D4GoahrieUPoMU8GCpVpR7MQqcKhmShIh8VlbEN3PLM3EBg==",
+      "optional": true,
+      "requires": {
+        "base64-arraybuffer": "^1.0.1"
+      },
+      "dependencies": {
+        "base64-arraybuffer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
+          "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
+          "optional": true
+        }
+      }
     },
     "uuid": {
       "version": "3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3264,8 +3264,7 @@
     "base64-arraybuffer": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "optional": true
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -4679,7 +4678,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.0.1.tgz",
       "integrity": "sha512-gwKYIMUn7xodIcb346wgUhE2Dt5O1Kmrc16PWi8sL4FTfyDj8P5095rzH7+O8CTZudJr+uw2GCI/hwEkDJFI2w==",
-      "optional": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0"
       }
@@ -6893,7 +6891,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.3.2.tgz",
       "integrity": "sha512-4+zqv87/a1LsaCrINV69wVLGG8GBZcYBboz1JPWEgiXcWoD9kroLzccsBRU/L9UlfV2MAZ+3J92U9IQPVMDeSQ==",
-      "optional": true,
       "requires": {
         "css-line-break": "2.0.1",
         "text-segmentation": "^1.0.2"
@@ -12096,7 +12093,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.2.tgz",
       "integrity": "sha512-uTqvLxdBrVnx/CFQOtnf8tfzSXFm+1Qxau7Xi54j4OPTZokuDOX8qncQzrg2G8ZicAMOM8TgzFAYTb+AqNO4Cw==",
-      "optional": true,
       "requires": {
         "utrie": "^1.0.1"
       }
@@ -12687,7 +12683,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.1.tgz",
       "integrity": "sha512-JPaDXF3vzgZxfeEwutdGzlrNoVFL5UvZcbO6Qo9D4GoahrieUPoMU8GCpVpR7MQqcKhmShIh8VlbEN3PLM3EBg==",
-      "optional": true,
       "requires": {
         "base64-arraybuffer": "^1.0.1"
       },
@@ -12695,8 +12690,7 @@
         "base64-arraybuffer": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
-          "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
-          "optional": true
+          "integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "element-ui": "^2.15.5",
+    "jspdf": "^2.3.1",
     "lodash": "^4.17.21",
     "tiptap-extensions": "^1.35.2",
     "vee-validate": "^3.4.11",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "element-ui": "^2.15.5",
+    "html2canvas": "^1.3.2",
     "jspdf": "^2.3.1",
     "lodash": "^4.17.21",
     "tiptap-extensions": "^1.35.2",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
   "blog.image.alt": "Blog image",
   "blog.noImage.text": "This blog has no cover image.",
   "blog.avatar.alt": "Avatar",
+  "blog.getAsPDF.text": "Get this blog as PDF",
 
   "general.blogs.title": "Blogs",
   "general.createBlog.title": "Create Blog",

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -29,7 +29,7 @@
         <div class="mb-20" v-html="get(blog, 'attributes.content', '')" />
       </div>
 
-      <base-button @click="getPDF">{{ $t('blog.getAsPDF.text') }}</base-button>
+      <base-button @click="getPDF" class="mb-3">{{ $t('blog.getAsPDF.text') }}</base-button>
     </div>
 
     <div class="hidden">

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -78,6 +78,7 @@ export default {
     async getPDF() {
       this.$refs.pdfContent.innerHTML = this.$refs.blog.innerHTML;
       const page = this.$refs.pdfContent;
+      const filename = get(this.blog, 'attributes.title', 'blog');
 
       var doc = new jsPDF({
         orientation: "p",
@@ -90,7 +91,7 @@ export default {
           scale: 0.54
         },
         callback: function (doc) {
-          doc.save(`${get(this.blog, 'attributes.title', 'blog')}.pdf`);
+          doc.save(`${filename}.pdf`);
         },
         x: 15,
         y: 20

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -33,7 +33,7 @@
     </div>
 
     <div class="hidden">
-      <div ref="pdfContent" style="width: 768px"></div>
+      <div ref="pdfContent" style="width: 768px; transform: translateY(-1rem);"></div>
     </div>
 
     <vue-scroll-progress-bar
@@ -88,13 +88,13 @@ export default {
 
       await doc.html(page, {
         html2canvas: {
-          scale: 0.54
+          scale: 0.38
         },
         callback: function (doc) {
           doc.save(`${filename}.pdf`);
         },
-        x: 15,
-        y: 20
+        x: 76.8,
+        y: 25
       });
 
       this.$refs.pdfContent.innerHTML = "";

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -86,28 +86,38 @@ export default {
     jsPDF,
 
     async getPDF() {
-      this.$refs.pdfContent.innerHTML = this.$refs.blog.innerHTML;
-      const page = this.$refs.pdfContent;
-      const filename = get(this.blog, 'attributes.title', 'blog');
+      try {
+        this.$refs.pdfContent.innerHTML = this.$refs.blog.innerHTML;
+        const page = this.$refs.pdfContent;
+        const filename = get(this.blog, 'attributes.title', 'blog');
 
-      var doc = new jsPDF({
-        orientation: "p",
-        format: "a4",
-        unit: "px"
-      });
+        const doc = new jsPDF({
+          orientation: "p",
+          format: "a4",
+          unit: "px"
+        });
 
-      await doc.html(page, {
-        html2canvas: {
-          scale: 0.38
-        },
-        callback: function (doc) {
-          doc.save(`${filename}.pdf`);
-        },
-        x: 76.8,
-        y: 25
-      });
+        const options = {
+          htmlScale: 0.38,
+          xOffset: 76.8,
+          yOffset: 25
+        }
 
-      this.$refs.pdfContent.innerHTML = "";
+        await doc.html(page, {
+          html2canvas: {
+            scale: options.htmlScale
+          },
+          callback: (doc) => {
+            doc.save(`${filename}.pdf`);
+          },
+          x: options.xOffset,
+          y: options.yOffset
+        });
+
+        this.$refs.pdfContent.innerHTML = "";
+      } catch (error) {
+        this.notifyErrors(error);
+      }
     },
 
     async getComments() {

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -12,21 +12,30 @@
         "
         :alt="$t('blog.image.alt')"
       />
-      <div class="tags cursor-pointer flex flex-wrap mx-auto space-x-4">
-        <div
-          class="inline-flex px-4 py-2.5 rounded-full text-sm font-medium bg-blue-100 text-blue-800 mb-2"
-          v-for="(tag, index) in get(blog, 'attributes.tags', [])"
-          :key="index"
-        >
-          {{ get(tag, 'value', '') }}
+      <div ref="blog">
+        <div class="tags cursor-pointer flex flex-wrap mx-auto space-x-4">
+          <div
+            class="inline-flex px-4 py-2.5 rounded-full text-sm font-medium bg-blue-100 text-blue-800 mb-2"
+            v-for="(tag, index) in get(blog, 'attributes.tags', [])"
+            :key="index"
+          >
+            {{ get(tag, 'value', '') }}
+          </div>
         </div>
-      </div>
-      <div class="title text-5xl my-5 text-center w-full">
-        {{ get(blog, 'attributes.title', '') }}
+        <div class="title text-5xl my-5 text-center w-full">
+          {{ get(blog, 'attributes.title', '') }}
+        </div>
+
+        <div class="mb-20" v-html="get(blog, 'attributes.content', '')" />
       </div>
 
-      <div class="mb-20" v-html="get(blog, 'attributes.content', '')" />
+      <base-button @click="getPDF">{{ $t('blog.getAsPDF.text') }}</base-button>
     </div>
+
+    <div class="hidden">
+      <div ref="pdfContent" style="width: 768px"></div>
+    </div>
+
     <vue-scroll-progress-bar
       backgroundColor="linear-gradient(to right, #BFDBFE,#4F46E5)"
       height=".3rem"
@@ -41,6 +50,7 @@ import get from 'lodash/get';
 import { getBlog, addViewOnBlog } from '@/api/blogService';
 import BackToTop from '@/components/BackToTop';
 import { VueScrollProgressBar } from '@guillaumebriday/vue-scroll-progress-bar';
+import jsPDF from 'jspdf';
 
 export default {
   name: 'Blog',
@@ -57,12 +67,37 @@ export default {
       data.attributes.tags = getTagsArray(get(data, 'attributes.tags', ''));
       await addViewOnBlog(this.blogId);
       this.blog = data;
+
     } catch (error) {
       this.notifyErrors(error);
     }
   },
   methods: {
     get,
+    jsPDF,
+    async getPDF() {
+      this.$refs.pdfContent.innerHTML = this.$refs.blog.innerHTML;
+      const page = this.$refs.pdfContent;
+
+      var doc = new jsPDF({
+        orientation: "p",
+        format: "a4",
+        unit: "px"
+      });
+
+      await doc.html(page, {
+        html2canvas: {
+          scale: 0.54
+        },
+        callback: function (doc) {
+          doc.save(`${get(this.blog, 'attributes.title', 'blog')}.pdf`);
+        },
+        x: 15,
+        y: 20
+      });
+
+      this.$refs.pdfContent.innerHTML = "";
+    }
   },
 };
 </script>


### PR DESCRIPTION
The implementation of export blog to pdf functionality is made with the jsPDF library. The button can be found at the end of every blog post page.

Unfortunately, the generated PDF does not includes the image of the blog because of some CORS error.

<img width="1440" alt="Screenshot 2021-09-03 at 15 04 59" src="https://user-images.githubusercontent.com/89005333/132002665-66674188-85c1-4d76-ab86-0cb053bca382.png">

<img width="1440" alt="Screenshot 2021-09-06 at 10 01 43" src="https://user-images.githubusercontent.com/89005333/132174296-514dbc36-ec0d-4e30-91dc-29e8dd42f75e.png">
